### PR TITLE
docs: ✏️ updated docs to reflect the changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # axe-linter-action
 
-A GitHub Action to lint for any accessibility issues in your pull requests.
+A GitHub Action to lint for any accessibility issues in your pull requests. This is a fork of the [offical action](https://github.com/dequelabs/axe-linter-action) from Deque.
+
+## Key Differences from the Offical Action
+
+- Dependencies are updated and will be maintained
+- You can choose the supported file types to be linted by the action
+- Linting is extended to the shell script as well
+- A debug mode has been added to the shell script
+- Semantic versioning will be used
 
 ## Input
+
+### `github_token`
+
+**Required** Your GitHub token for authentication.
 
 ### `api_key`
 
@@ -12,11 +24,15 @@ A GitHub Action to lint for any accessibility issues in your pull requests.
 
 **Optional** The URL for the axe-linter API. Defaults to `https://axe-linter.deque.com`.
 
+### `files_pattern`
+
+**Optional** File patterns to check for changes. Defaults to `'**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'`.
+
 \* To request an API key for axe-linter, please visit [accessibility.deque.com/linter-contact-us](https://accessibility.deque.com/linter-contact-us). Once provisioned please visit [https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key](https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key) to get your API key.
 
 ## Example Usage
 
-Create a file in your repository called `.github/workflows/axe-linter.yml` with the following contents:
+Create a file in your repository called `.github/workflows/axe-linter.yml` with the following contents, or add the steps to an existing workflow:
 
 ```yaml
 name: Lint for accessibility issues
@@ -28,9 +44,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: dequelabs/axe-linter-action@v1
+      - uses: actions/checkout@v4
+      - uses: mattbangert/axe-linter-action
         with:
-          api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-```
+          api_key: ${{ secrets.AXE_LINTER_API_KEY }}
+          axe_linter_url: https://axe-linter.deque.com
+          files_pattern: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'


### PR DESCRIPTION
This pull request primarily focuses on updating the `README.md` file to reflect changes in the `axe-linter-action`. The changes include specifying the key differences between this fork and the official action, adding a new `github_token` input, updating the `files_pattern` input, and modifying the example usage section to reflect the changes. 

Key Differences from the Official Action:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R18): The document now includes a section detailing the key differences between this fork and the official action. This includes updates to dependencies, the addition of file type selection for linting, extension of linting to shell scripts, a debug mode for the shell script, and the use of semantic versioning.

New and Updated Inputs:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R18): A new `github_token` input has been added, which is required for authentication. The `files_pattern` input has also been updated to include a default value. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R35)

Example Usage:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R53): The example usage section has been updated to reflect the changes. This includes updating the `actions/checkout` to v4, specifying the use of `mattbangert/axe-linter-action` instead of `dequelabs/axe-linter-action@v1`, and adding the new and updated inputs in the `with` clause.