### PR TITLE
feat: 🎸 add support for ignoring files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ A GitHub Action to lint for any accessibility issues in your pull requests. This
 
 **Optional** File patterns to check for changes. Defaults to `'**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'`.
 
+### `files_ignore_pattern`
+
+**Optional** File patterns to ignore. Example: `**/test/*,**/docs/*`.
+
 \* To request an API key for axe-linter, please visit [accessibility.deque.com/linter-contact-us](https://accessibility.deque.com/linter-contact-us). Once provisioned please visit [https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key](https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key)to get your API key.
 
 ## Environment Variables

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: 'File patterns to check for changes'
     required: false
     default: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown' # Default patterns
+  files_ignore_pattern:
+    description: 'File patterns to ignore'
+    required: false
 
 runs:
   using: 'composite'
@@ -48,6 +51,8 @@ runs:
       with:
         files: ${{ inputs.files_pattern }}
         files_separator: ','
+        files_ignore: ${{ inputs.files_ignore_pattern }}
+        files_ignore_separator: ','
     - name: Run axe linter
       if: steps.changed_files.outputs.any_changed == 'true'
       run: ${{ github.action_path }}/axe-linter.sh


### PR DESCRIPTION
This pull request introduces a new feature to the GitHub Action for linting accessibility issues, specifically adding support for ignoring certain file patterns. The most important changes include updates to the `README.md` and `action.yml` files to document and implement this new feature.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R39): Added a new section to document the `files_ignore_pattern` option, which allows users to specify file patterns to ignore.

Implementation updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R21-R23): Introduced a new input `files_ignore_pattern` to specify file patterns to ignore.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R54-R55): Updated the `runs` section to pass the `files_ignore_pattern` input to the action, along with a separator for the ignored files.