### PR TITLE
Make Linter Action more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # axe-linter-action
+
 ![GitHub last commit](https://img.shields.io/github/last-commit/mattbangert/axe-linter-action) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mattbangert/axe-linter-action/lint-test.yml) ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/mattbangert/axe-linter-action/total) ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/mattbangert/axe-linter-action) ![GitHub Release](https://img.shields.io/github/v/release/mattbangert/axe-linter-action)
-
-
-
-
 
 A GitHub Action to lint for any accessibility issues in your pull requests. This is a fork of the [offical action](https://github.com/dequelabs/axe-linter-action) from Deque.
 
@@ -31,11 +28,13 @@ A GitHub Action to lint for any accessibility issues in your pull requests. This
 
 ### `files_pattern`
 
-**Optional** File patterns to check for changes. Defaults to `'**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'`.
+**Optional** File patterns to check for changes. Defaults to `'**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'`.\
+You may also use a multiline string to specify multiple patterns.
 
 ### `files_ignore_pattern`
 
-**Optional** File patterns to ignore. Example: `**/test/*,**/docs/*`.
+**Optional** File patterns to ignore. Example: `**/test/*,**/docs/*`.\
+You may also use a multiline string to specify multiple patterns.
 
 \* To request an API key for axe-linter, please visit [accessibility.deque.com/linter-contact-us](https://accessibility.deque.com/linter-contact-us). Once provisioned please visit [https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key](https://docs.deque.com/linter/1.0.0/en/axe-linter-api-key)to get your API key.
 
@@ -70,4 +69,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           axe_linter_url: https://axe-linter.deque.com
-          files_pattern: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'
+          files_pattern: "**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown"
+```
+
+If you need to better define your inclusions/exclusions, you may use a combination of `files_pattern` and `files_ignore_pattern`:
+
+```yaml
+files_pattern: |
+  packages/client/**/*.{js,jsx,tsx,html,vue}
+  src/**/*.{js,jsx,tsx,html,vue}
+files_ignore_pattern: |
+  src/**/*_test.{js,jsx,tsx,html,vue}
+  **/tests/**/*.{js,jsx,tsx,html,htm,vue}
+```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           api_key: ${{ secrets.AXE_LINTER_API_KEY }}
           axe_linter_url: https://axe-linter.deque.com
-          files_pattern: "**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown"
+          files_pattern: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown'
 ```
 
 If you need to better define your inclusions/exclusions, you may use a combination of `files_pattern` and `files_ignore_pattern`:

--- a/action.yml
+++ b/action.yml
@@ -28,18 +28,45 @@ runs:
     - uses: actions/checkout@v4
     - name: Validate file patterns
       run: |
-        echo "i'm here!"
         SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
         PATTERN_INPUT="${{ inputs.files_pattern }}"
-        # Split patterns into an array
-        IFS=' ' read -r -a PATTERNS <<< "$PATTERN_INPUT"
+        # Split multiline input into an array of lines
+        IFS=$'\n' read -r -d '' -a PATTERNS <<< "$PATTERN_INPUT"
+
         for pattern in "${PATTERNS[@]}"; do
-          # Extract the extension from the pattern
-          EXTENSION="${pattern##*.}"
-          # Check if the extension is in the list of supported extensions
-          if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
-            echo "::error::Unsupported file extension detected: $EXTENSION"
-            exit 1
+          # Check for negated patterns
+          if [[ "$pattern" =~ ^! ]]; then
+            echo "Skipping negated pattern: $pattern"
+            continue
+          fi
+
+          # Detect brace expansion and handle it
+          if [[ "$pattern" =~ \{.*?\} ]]; then
+            # Extract braces content and split by commas
+            BRACE_CONTENT="${pattern##*\{}"
+            BRACE_CONTENT="${BRACE_CONTENT%%\}*}"
+            IFS=',' read -r -a EXTENSIONS <<< "$BRACE_CONTENT"
+
+            for EXTENSION in "${EXTENSIONS[@]}"; do
+              # Check if the extension is in the list of supported extensions
+              if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
+                echo "::error::Unsupported file extension detected: $EXTENSION in pattern $pattern"
+                exit 1
+              fi
+            done
+          else
+            # Handle patterns without braces separately, extract extension
+            EXTENSION="${pattern##*.}"
+            # In case there's no clearer ".ext" part, we should skip it
+            if [[ "$EXTENSION" == "$pattern" ]]; then
+              echo "Skipping pattern without clear extension: $pattern"
+              continue
+            fi
+            # Check if the extension is in the list of supported extensions
+            if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
+              echo "::error::Unsupported file extension detected: $EXTENSION in pattern $pattern"
+              exit 1
+            fi
           fi
         done
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,7 @@ runs:
     - name: Validate file patterns
       run: |
         SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
-        # PATTERN_INPUT="${{ steps.changed_files.outputs.all_changed_files }}"
-        PATTERN_INPUT="packages/client/ui/src/component-library/Button.tsx src/app/actions/project/create/projectCreate.js"
+        PATTERN_INPUT="${{ steps.changed_files.outputs.all_changed_files }}"
         # Split patterns into an array
         IFS=' ' read -r -a PATTERNS <<< "$PATTERN_INPUT"
         for pattern in "${PATTERNS[@]}"; do

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: Run axe Accessibility Linter
 description: Lints all changed files using the axe DevTools Linter
 branding:
-  icon: "check-circle"
-  color: "blue"
+  icon: 'check-circle'
+  color: 'blue'
 inputs:
   github_token:
     description: Github Token
@@ -15,15 +15,15 @@ inputs:
     required: false
     default: https://axe-linter.deque.com
   files_pattern:
-    description: "File patterns to check for changes"
+    description: 'File patterns to check for changes'
     required: false
-    default: "**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown" # Default patterns
+    default: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown' # Default patterns
   files_ignore_pattern:
-    description: "File patterns to ignore"
+    description: 'File patterns to ignore'
     required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/checkout@v4
     - name: Get changed files

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         # files_ignore_separator: ","
     - name: List all changed files
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: mikefarah/yq@master
     - name: Get changed files
       id: changed_files
       env:
@@ -34,6 +33,7 @@ runs:
       uses: tj-actions/changed-files@v45
       with:
         files: ${{ inputs.files_pattern }}
+        files_ignore: ${{ inputs.files_ignore_pattern }}
     - name: List all changed files
       env:
         ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,7 @@ runs:
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"
         done
+      shell: bash
     - name: Run axe linter
       if: steps.changed_files.outputs.any_changed == 'true'
       run: ${{ github.action_path }}/axe-linter.sh

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: Run axe Accessibility Linter
 description: Lints all changed files using the axe DevTools Linter
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 inputs:
   github_token:
     description: Github Token
@@ -15,19 +15,20 @@ inputs:
     required: false
     default: https://axe-linter.deque.com
   files_pattern:
-    description: 'File patterns to check for changes'
+    description: "File patterns to check for changes"
     required: false
-    default: '**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown' # Default patterns
+    default: "**/*.js,**/*.jsx,**/*.tsx,**/*.html,**/*.vue,**/*.md,**/*.markdown" # Default patterns
   files_ignore_pattern:
-    description: 'File patterns to ignore'
+    description: "File patterns to ignore"
     required: false
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v4
     - name: Validate file patterns
       run: |
+        echo "i'm here!"
         SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
         PATTERN_INPUT="${{ inputs.files_pattern }}"
         # Split patterns into an array
@@ -50,9 +51,9 @@ runs:
       uses: tj-actions/changed-files@cc733854b1f224978ef800d29e4709d5ee2883e4
       with:
         files: ${{ inputs.files_pattern }}
-        files_separator: ','
+        files_separator: ","
         files_ignore: ${{ inputs.files_ignore_pattern }}
-        files_ignore_separator: ','
+        files_ignore_separator: ","
     - name: Run axe linter
       if: steps.changed_files.outputs.any_changed == 'true'
       run: ${{ github.action_path }}/axe-linter.sh

--- a/action.yml
+++ b/action.yml
@@ -25,51 +25,40 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-    - name: Validate file patterns
-      run: |
-        SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
-        PATTERN_INPUT="${{ inputs.files_pattern }}"
-        # Split multiline input into an array of lines
-        IFS=$'\n' read -r -d '' -a PATTERNS <<< "$PATTERN_INPUT"
-
-        for pattern in "${PATTERNS[@]}"; do
-          # Check for negated patterns
-          if [[ "$pattern" =~ ^! ]]; then
-            echo "Skipping negated pattern: $pattern"
-            continue
-          fi
-
-          # Detect brace expansion and handle it
-          if [[ "$pattern" =~ \{.*?\} ]]; then
-            # Extract braces content and split by commas
-            BRACE_CONTENT="${pattern##*\{}"
-            BRACE_CONTENT="${BRACE_CONTENT%%\}*}"
-            IFS=',' read -r -a EXTENSIONS <<< "$BRACE_CONTENT"
-
-            for EXTENSION in "${EXTENSIONS[@]}"; do
-              # Check if the extension is in the list of supported extensions
-              if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
-                echo "::error::Unsupported file extension detected: $EXTENSION in pattern $pattern"
-                exit 1
-              fi
-            done
-          else
-            # Handle patterns without braces separately, extract extension
-            EXTENSION="${pattern##*.}"
-            # In case there's no clearer ".ext" part, we should skip it
-            if [[ "$EXTENSION" == "$pattern" ]]; then
-              echo "Skipping pattern without clear extension: $pattern"
-              continue
-            fi
-            # Check if the extension is in the list of supported extensions
-            if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
-              echo "::error::Unsupported file extension detected: $EXTENSION in pattern $pattern"
-              exit 1
-            fi
-          fi
-        done
-      shell: bash
+    # - uses: actions/checkout@v4
+    # - name: Validate file patterns
+    #   run: |
+    #     SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
+    #     PATTERN_INPUT="${{ inputs.files_pattern }}"
+    #     echo "Checking input: $PATTERN_INPUT"
+    #     # Split patterns into an array
+    #     IFS=$'\n' read -r -d '' -a PATTERNS <<< "$(echo "$PATTERN_INPUT" | xargs -n1)"
+    #     for pattern in "${PATTERNS[@]}"; do
+    #           echo "Checking array: $pattern"
+    #     done
+    #     for pattern in "${PATTERNS[@]}"; do
+    #       echo "Checking pattern: $pattern"
+    #       # Extract the extension from the pattern
+    #       EXTENSION="${pattern##*.}"
+    #       echo "Checking extension: $EXTENSION"
+    #       NEXT_CHAR="${EXTENSION:0:1}"
+    #         echo "Next character in extension: $NEXT_CHAR"
+    #         if [[ "$NEXT_CHAR" == "{" ]]; then
+    #         NEW_EXTENSION="${pattern#*\{}"
+    #         NEW_EXTENSION="${NEW_EXTENSION%\}*}"
+    #         echo "Checking extension: $NEW_EXTENSION"
+    #           IFS=',' read -r -a PATTERNS1 <<< "$NEW_EXTENSION"
+    #           for pattern1 in "${PATTERNS1[@]}"; do
+    #             echo "Checking extension: $pattern1"
+    #             # Check if the extension is in the list of supported extensions
+    #             if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $pattern1 " ]]; then
+    #               echo "::error::Unsupported file extension detected: $pattern1"
+    #           exit 1
+    #           fi
+    #           done
+    #         fi
+    #     done
+    #   shell: bash
     - uses: mikefarah/yq@master
     - name: Get changed files
       id: changed_files

--- a/action.yml
+++ b/action.yml
@@ -25,41 +25,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - uses: actions/checkout@v4
-    # - name: Validate file patterns
-    #   run: |
-    #     SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
-    #     PATTERN_INPUT="${{ inputs.files_pattern }}"
-    #     echo "Checking input: $PATTERN_INPUT"
-    #     # Split patterns into an array
-    #     IFS=$'\n' read -r -d '' -a PATTERNS <<< "$(echo "$PATTERN_INPUT" | xargs -n1)"
-    #     for pattern in "${PATTERNS[@]}"; do
-    #           echo "Checking array: $pattern"
-    #     done
-    #     for pattern in "${PATTERNS[@]}"; do
-    #       echo "Checking pattern: $pattern"
-    #       # Extract the extension from the pattern
-    #       EXTENSION="${pattern##*.}"
-    #       echo "Checking extension: $EXTENSION"
-    #       NEXT_CHAR="${EXTENSION:0:1}"
-    #         echo "Next character in extension: $NEXT_CHAR"
-    #         if [[ "$NEXT_CHAR" == "{" ]]; then
-    #         NEW_EXTENSION="${pattern#*\{}"
-    #         NEW_EXTENSION="${NEW_EXTENSION%\}*}"
-    #         echo "Checking extension: $NEW_EXTENSION"
-    #           IFS=',' read -r -a PATTERNS1 <<< "$NEW_EXTENSION"
-    #           for pattern1 in "${PATTERNS1[@]}"; do
-    #             echo "Checking extension: $pattern1"
-    #             # Check if the extension is in the list of supported extensions
-    #             if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $pattern1 " ]]; then
-    #               echo "::error::Unsupported file extension detected: $pattern1"
-    #           exit 1
-    #           fi
-    #           done
-    #         fi
-    #     done
-    #   shell: bash
-    # - uses: mikefarah/yq@master
+    - uses: actions/checkout@v4
+    - uses: mikefarah/yq@master
     - name: Get changed files
       id: changed_files
       env:
@@ -67,15 +34,29 @@ runs:
       uses: tj-actions/changed-files@v45
       with:
         files: ${{ inputs.files_pattern }}
-        # files_separator: ","
-        # files_ignore: ${{ inputs.files_ignore_pattern }}
-        # files_ignore_separator: ","
     - name: List all changed files
       env:
         ALL_CHANGED_FILES: ${{ steps.changed_files.outputs.all_changed_files }}
       run: |
         for file in ${ALL_CHANGED_FILES}; do
           echo "$file was changed"
+        done
+      shell: bash
+    - name: Validate file patterns
+      run: |
+        SUPPORTED_EXTENSIONS="js jsx tsx html vue md markdown"
+        # PATTERN_INPUT="${{ steps.changed_files.outputs.all_changed_files }}"
+        PATTERN_INPUT="packages/client/ui/src/component-library/Button.tsx src/app/actions/project/create/projectCreate.js"
+        # Split patterns into an array
+        IFS=' ' read -r -a PATTERNS <<< "$PATTERN_INPUT"
+        for pattern in "${PATTERNS[@]}"; do
+          # Extract the extension from the pattern
+          EXTENSION="${pattern##*.}"
+          # Check if the extension is in the list of supported extensions
+          if [[ ! " $SUPPORTED_EXTENSIONS " =~ " $EXTENSION " ]]; then
+            echo "::error::Unsupported file extension detected: $EXTENSION"
+            exit 1
+          fi
         done
       shell: bash
     - name: Run axe linter

--- a/action.yml
+++ b/action.yml
@@ -59,17 +59,17 @@ runs:
     #         fi
     #     done
     #   shell: bash
-    - uses: mikefarah/yq@master
+    # - uses: mikefarah/yq@master
     - name: Get changed files
       id: changed_files
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-      uses: tj-actions/changed-files@cc733854b1f224978ef800d29e4709d5ee2883e4
+      uses: tj-actions/changed-files@v45
       with:
         files: ${{ inputs.files_pattern }}
-        files_separator: ","
-        files_ignore: ${{ inputs.files_ignore_pattern }}
-        files_ignore_separator: ","
+        # files_separator: ","
+        # files_ignore: ${{ inputs.files_ignore_pattern }}
+        # files_ignore_separator: ","
     - name: List all changed files
       env:
         ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,13 @@ runs:
         files_separator: ","
         files_ignore: ${{ inputs.files_ignore_pattern }}
         files_ignore_separator: ","
+    - name: List all changed files
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        for file in ${ALL_CHANGED_FILES}; do
+          echo "$file was changed"
+        done
     - name: Run axe linter
       if: steps.changed_files.outputs.any_changed == 'true'
       run: ${{ github.action_path }}/axe-linter.sh


### PR DESCRIPTION
After going about this the completely wrong way, I finally landed on these small changes which should allow us more configurability. 

By getting the changed file before we do any validation, it makes the validation significantly easier. We know the format of inclusions/exclusions will be a fixed format because we can take the output from grabbing only changed files. Before, we were validating the extensions in the patterns provided by the suite, instead of the actually checking the extensions on the files themselves. 

By changing the validation to use the output of `changed-files`, we are focusing on the files themselves instead of the patterns. This way, each suite can use whatever pattern they'd like: single line command separated, multiple line, negation operators, etc. The `changed-files` action can handle all that, so no need for us to do so inside our validation. 

I can't say this will cover every scenario we'll be faced with, but should handle most of them. I tested this using various input patterns sent to the action:
- Single line comma separated
- Multiline
- Using negation operators within `files_pattern`
- Using a combination of `files_pattern` and `files_ignore_pattern`